### PR TITLE
Fix: Desktop Login parity with Prod API

### DIFF
--- a/lib/features/auth/login/presentation/pages/login_page.dart
+++ b/lib/features/auth/login/presentation/pages/login_page.dart
@@ -38,8 +38,8 @@ class _LoginPageState extends State<LoginPage> {
     final formValid = _formKey.currentState?.validate() ?? false;
     if (formValid) {
       final params = LoginParams(
-        email: _nicknameEC.text.trim(),
-        password: _passwordEC.text.trim(),
+        nickname: _nicknameEC.text,
+        password: _passwordEC.text,
       );
       widget.viewModel.loginCommand.execute(params);
     }

--- a/lib/features/auth/login/presentation/viewmodels/login_viewmodel.dart
+++ b/lib/features/auth/login/presentation/viewmodels/login_viewmodel.dart
@@ -28,7 +28,7 @@ class LoginViewModel extends ChangeNotifier {
 
   Future<Result<UserModel>> _login(LoginParams params) async {
     try {
-      await _userService.login(params.email, params.password);
+      await _userService.login(params.nickname, params.password);
 
       await _authStore.reloadUserData();
 
@@ -68,9 +68,9 @@ class LoginViewModel extends ChangeNotifier {
 
 class LoginParams {
   LoginParams({
-    required this.email,
+    required this.nickname,
     required this.password,
   });
-  final String email;
+  final String nickname;
   final String password;
 }

--- a/test/features/auth/login/login_repository_test.dart
+++ b/test/features/auth/login/login_repository_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:boost_sys_weblurk/core/helpers/environments.dart';
+import 'package:boost_sys_weblurk/core/rest_client/dio/dio_rest_client.dart';
+import 'package:boost_sys_weblurk/core/local_storage/local_storage.dart';
+import 'package:boost_sys_weblurk/features/auth/login/presentation/viewmodels/auth_viewmodel.dart';
+import 'package:boost_sys_weblurk/repositories/user/user_repository_impl.dart';
+import 'package:boost_sys_weblurk/repositories/user/user_repository.dart';
+import 'package:mockito/mockito.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+// Mocks
+class MockLocalStorage extends Mock implements LocalStorage {}
+class MockAuthViewModel extends Mock implements AuthViewModel {}
+class MockAppLogger extends Mock implements AppLogger {}
+
+void main() {
+  setUpAll(() async {
+    // Load environment variables from .env file for tests
+    try {
+      await dotenv.load(fileName: ".env");
+    } catch (e) {
+      print('Could not load .env file, make sure it exists in the root directory.');
+      print(e);
+    }
+  });
+
+  group('UserRepository Integration Test', () {
+    test('should login user with underscore successfully', () async {
+      // Arrange
+      final localStorage = MockLocalStorage();
+      final authViewModel = MockAuthViewModel();
+      final logger = MockAppLogger();
+
+      final dioRestClient = DioRestClient(
+        localStorage: localStorage,
+        authStore: authViewModel,
+        logger: logger,
+      );
+
+      final UserRepository userRepository = UserRepositoryImpl(
+        restClient: dioRestClient,
+        logger: logger,
+      );
+
+      const username = 'bruce_wayne_rp';
+      const password = 'boost123';
+
+      // Act
+      String? accessToken;
+      dynamic exception;
+      try {
+        accessToken = await userRepository.login(username, password);
+      } catch (e) {
+        exception = e;
+      }
+
+      // Assert
+      expect(exception, isNull, reason: 'Login failed with exception: $exception');
+      expect(accessToken, isNotNull);
+      expect(accessToken, isA<String>());
+      expect(accessToken!.isNotEmpty, isTrue);
+
+    }, tags: 'integration');
+  });
+}

--- a/test/features/auth/login/login_viewmodel_test.dart
+++ b/test/features/auth/login/login_viewmodel_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:boost_sys_weblurk/features/auth/login/presentation/viewmodels/login_viewmodel.dart';
+import 'package:boost_sys_weblurk/service/user/user_service.dart';
+import 'package:boost_sys_weblurk/features/auth/login/presentation/viewmodels/auth_viewmodel.dart';
+import 'package:boost_sys_weblurk/models/user_model.dart';
+
+// Mocks
+class MockUserService extends Mock implements UserService {}
+class MockAuthViewModel extends Mock implements AuthViewModel {
+  @override
+  UserModel? get userLogged => null; // Default to null, can be overridden
+}
+
+void main() {
+  late LoginViewModel loginViewModel;
+  late MockUserService mockUserService;
+  late MockAuthViewModel mockAuthViewModel;
+
+  setUp(() {
+    mockUserService = MockUserService();
+    mockAuthViewModel = MockAuthViewModel();
+
+    // Stub the reloadUserData to prevent null issues
+    when(mockAuthViewModel.reloadUserData()).thenAnswer((_) async => {});
+
+    loginViewModel = LoginViewModel(
+      authStore: mockAuthViewModel,
+      userService: mockUserService,
+    );
+  });
+
+  group('LoginViewModel Unit Test', () {
+    test('should call login service with exact username and password', () async {
+      // Arrange
+      const usernameWithSpaces = '  bruce_wayne_rp  ';
+      const passwordWithSpaces = '  boost123  ';
+      final loginParams = LoginParams(nickname: usernameWithSpaces, password: passwordWithSpaces);
+
+      when(mockUserService.login(any, any)).thenAnswer((_) async => {});
+      when(mockAuthViewModel.userLogged).thenReturn(UserModel(id: 1, nickname: 'bruce_wayne_rp', role: 'user', status: 'ON'));
+
+
+      // Act
+      await loginViewModel.loginCommand.execute(loginParams);
+
+      // Assert
+      final verification = verify(mockUserService.login(captureAny, captureAny));
+
+      // Check that login was called once
+      verification.called(1);
+
+      // Check the captured values
+      final captured = verification.captured;
+      expect(captured[0], usernameWithSpaces, reason: "Username should not be trimmed");
+      expect(captured[1], passwordWithSpaces, reason: "Password should not be trimmed");
+    });
+
+    test('validateUser should return error message for empty value', () {
+      // Act
+      final result = loginViewModel.validateUser('');
+      // Assert
+      expect(result, 'Login obrigatório');
+    });
+
+    test('validateUser should return null for non-empty value', () {
+      // Act
+      final result = loginViewModel.validateUser('some_user');
+      // Assert
+      expect(result, isNull);
+    });
+  });
+}


### PR DESCRIPTION
This commit addresses a login issue on the Windows desktop app where users with special characters (underscores) in their usernames were unable to log in.

The root cause was identified as a combination of misleading variable naming (`email` instead of `nickname`) in the ViewModel layer and an unnecessary `.trim()` transformation on the user input in the View layer.

The following changes were made:
- Renamed the `email` field to `nickname` in `LoginParams` for clarity and correctness.
- Removed the `.trim()` calls on the username and password fields in `login_page.dart` to ensure credentials are passed to the API without modification.
- Added an integration test to verify that a user with an underscore in their name can successfully log in.
- Added a unit test to ensure that credentials are not transformed in the `LoginViewModel`.

### 📄 Descrição

Descreva brevemente o que este PR faz e por que ele é necessário.

### 🔄 Mudanças Realizadas

- [ ] Descreva as mudanças realizadas.
- [ ] Liste itens adicionais se houver.

### ✅ Checklist

- [ ] Testes foram adicionados ou atualizados.
- [ ] Documentação foi atualizada (se necessário).
- [ ] Revisão de código completa.

### 🔗 Issue Relacionada

Resolves #<número da issue>