### PR TITLE
fix: ScreenUtil config, login error handling and schedule list parsing

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-base_url=https://api.boostapi.com.br
-# base_url=http://localhost:8000
+# base_url=https://api.boostapi.com.br
+base_url=http://localhost:8080
 rest_client_connect_timeout=60000
 rest_client_receive_timeout=60000
 VAPID_KEY=BNRrBKDA0yKRrj54bzuLiqa-gXORv1hlGs0tAtgKIw7r2w0xjQBR0VKHcYPxvONOi9bHCu96

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,9 @@
 
 include: package:flutter_lints/flutter.yaml
 
+formatter:
+  preserve-trailing-commas: true
+
 analyzer:
   errors:
     constant_identifier_names: ignore
@@ -32,7 +35,7 @@ linter:
     prefer_conditional_assignment: true
     prefer_const_constructors: true
     prefer_contains: true
-    prefer_equal_for_default_values: true
+    # prefer_equal_for_default_values: removed in Dart 3.0
     prefer_final_fields: true
     prefer_final_locals: true
     prefer_initializing_formals: true

--- a/lib/core/application_config.dart
+++ b/lib/core/application_config.dart
@@ -25,11 +25,8 @@ class ApplicationConfig {
     try {
       await windowManager.ensureInitialized();
 
-      windowManager.setSize(
-        const Size(1014, 624),
-      );
-
-      windowManager.setResizable(false);
+      windowManager.setMinimumSize(const Size(1366, 768));
+      windowManager.setSize(const Size(1366, 768));
     } catch (e, s) {
       log('Error configuring window manager: $e');
       log('StackTrace: $s');

--- a/lib/core/local_storage/flutter_secure_storage/flutter_secure_storage_local_storage_impl.dart
+++ b/lib/core/local_storage/flutter_secure_storage/flutter_secure_storage_local_storage_impl.dart
@@ -2,11 +2,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../local_storage.dart';
 
 class FlutterSecureStorageLocalStorageImpl implements LocalSecureStorage {
-  FlutterSecureStorage get _instance => const FlutterSecureStorage(
-        aOptions: AndroidOptions(
-          encryptedSharedPreferences: true,
-        ),
-      );
+  FlutterSecureStorage get _instance => const FlutterSecureStorage();
 
   @override
   Future<void> clear() async {

--- a/lib/core/ui/extensions/responsive_breakpoints.dart
+++ b/lib/core/ui/extensions/responsive_breakpoints.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+enum ScreenType { tablet, desktop, desktopLarge }
+
+class ResponsiveBreakpoints {
+  ResponsiveBreakpoints._();
+
+  static const double tabletMinWidth = 720;
+  static const double desktopMinWidth = 1366;
+  static const double desktopLargeMinWidth = 1920;
+
+  static ScreenType getScreenType(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+
+    if (width >= desktopLargeMinWidth) return ScreenType.desktopLarge;
+    if (width >= desktopMinWidth) return ScreenType.desktop;
+    return ScreenType.tablet;
+  }
+
+  static bool isTablet(BuildContext context) =>
+      getScreenType(context) == ScreenType.tablet;
+
+  static bool isDesktop(BuildContext context) =>
+      getScreenType(context) == ScreenType.desktop ||
+      getScreenType(context) == ScreenType.desktopLarge;
+
+  static bool isDesktopLarge(BuildContext context) =>
+      getScreenType(context) == ScreenType.desktopLarge;
+
+  static T responsiveValue<T>(
+    BuildContext context, {
+    required T tablet,
+    required T desktop,
+    T? desktopLarge,
+  }) {
+    final type = getScreenType(context);
+    return switch (type) {
+      ScreenType.desktopLarge => desktopLarge ?? desktop,
+      ScreenType.desktop => desktop,
+      ScreenType.tablet => tablet,
+    };
+  }
+}

--- a/lib/features/auth/login/presentation/pages/login_page.dart
+++ b/lib/features/auth/login/presentation/pages/login_page.dart
@@ -32,6 +32,8 @@ class _LoginPageState extends State<LoginPage> {
   final _confirmPasswordEC = TextEditingController();
 
   bool _isRegisterMode = false;
+  bool _loginHandled = false;
+  bool _registerHandled = false;
   late final RegisterViewModel _registerViewModel;
 
   @override
@@ -58,6 +60,7 @@ class _LoginPageState extends State<LoginPage> {
         nickname: _nicknameEC.text,
         password: _passwordEC.text,
       );
+      _loginHandled = false;
       widget.viewModel.loginCommand.execute(params);
     }
   }
@@ -79,6 +82,7 @@ class _LoginPageState extends State<LoginPage> {
         password: _passwordEC.text,
         confirmPassword: _confirmPasswordEC.text,
       );
+      _registerHandled = false;
       _registerViewModel.registerCommand.execute(params);
     }
   }
@@ -273,13 +277,15 @@ class _LoginPageState extends State<LoginPage> {
             builder: (context, child) {
               final command = widget.viewModel.loginCommand;
 
-              if (command.completed) {
+              if (command.completed && !_loginHandled) {
+                _loginHandled = true;
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   context.go(AppRoutes.home);
                 });
               }
 
-              if (command.error) {
+              if (command.error && !_loginHandled) {
+                _loginHandled = true;
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   final error = command.result?.errorOrNull;
                   ErrorMessageService.instance.handleLoginError(error);
@@ -296,14 +302,16 @@ class _LoginPageState extends State<LoginPage> {
             builder: (context, child) {
               final command = _registerViewModel.registerCommand;
 
-              if (command.completed) {
+              if (command.completed && !_registerHandled) {
+                _registerHandled = true;
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   Messages.success('Cadastro realizado com sucesso!');
-                  _toggleMode(); // Volta para o modo de login
+                  _toggleMode();
                 });
               }
 
-              if (command.error) {
+              if (command.error && !_registerHandled) {
+                _registerHandled = true;
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   final error = command.result?.errorOrNull;
                   ErrorMessageService.instance.handleLoginError(error);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'core/application_config.dart';
@@ -26,11 +27,12 @@ Future<void> main() async {
 
       await ApplicationConfig().consfigureApp();
 
-      // Initialize window manager only for Windows
-      if (Platform.isWindows) {
+      // Initialize window manager only for Windows and MacOS
+      if (Platform.isWindows || Platform.isMacOS) {
         await windowManager.ensureInitialized();
         final WindowOptions windowOptions = const WindowOptions(
-          size: Size(1014, 624),
+          size: Size(1366, 768),
+          minimumSize: Size(1366, 768),
           center: true,
         );
         windowManager.waitUntilReadyToShow(windowOptions, () async {
@@ -80,12 +82,19 @@ class _WeblurklState extends State<Weblurk> {
 
   @override
   Widget build(BuildContext context) {
-    return AndroidBackButtonHandler(
-      child: MaterialApp.router(
-        routerConfig: AppRouter.router,
-        title: UiConfig.title,
-        theme: UiConfig.theme,
-      ),
+    return ScreenUtilInit(
+      designSize: const Size(1366, 768),
+      minTextAdapt: true,
+      splitScreenMode: true,
+      builder: (context, child) {
+        return AndroidBackButtonHandler(
+          child: MaterialApp.router(
+            routerConfig: AppRouter.router,
+            title: UiConfig.title,
+            theme: UiConfig.theme,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/repositories/home/home_repository_impl.dart
+++ b/lib/repositories/home/home_repository_impl.dart
@@ -187,7 +187,19 @@ class HomeRepositoryImpl implements HomeRepository {
 
       if (response.statusCode == 200) {
         if (response.data != null) {
-          final result = ScheduleListModel.fromMap(response.data);
+          if (response.data is List) {
+            final schedules = (response.data as List)
+                .map((e) =>
+                    ScheduleModel.fromMap(e as Map<String, dynamic>))
+                .toList();
+            return ScheduleListModel(
+              listName: listName,
+              schedules: schedules,
+            );
+          }
+          final result = ScheduleListModel.fromMap(
+            response.data as Map<String, dynamic>,
+          );
           return result;
         }
         return null;

--- a/lib/repositories/user/user_repository_impl.dart
+++ b/lib/repositories/user/user_repository_impl.dart
@@ -69,26 +69,35 @@ class UserRepositoryImpl implements UserRepository {
         throw Failure(message: 'Token de acesso não encontrado na resposta');
       }
     } on RestClientException catch (e, s) {
-      if (e.statusCode == HttpStatus.badRequest ||
+      final errorMessage = e.response.data?['message'] as String?;
+
+      if (e.statusCode == HttpStatus.notFound ||
+          e.statusCode == HttpStatus.badRequest ||
           e.statusCode == HttpStatus.forbidden) {
-        final errorMessage = e.response.data?['message'] ?? 'Erro de validação';
-        if (errorMessage.contains('User not exists') ||
-            errorMessage.contains('User not found')) {
+        if (errorMessage != null &&
+            (errorMessage.contains('User not exists') ||
+                errorMessage.contains('User not found') ||
+                errorMessage.contains('User or password invalid'))) {
           throw Failure(
-            message: 'Usuario não encontrado, entre em contato com o suporte!!',
+            message: 'Usuário ou senha inválidos',
           );
         }
+        throw Failure(message: errorMessage ?? 'Erro de autenticação');
       }
 
-      // Tratamento específico para erros de conexão
+      if (e.statusCode == HttpStatus.unauthorized) {
+        throw Failure(message: errorMessage ?? 'Credenciais inválidas');
+      }
+
       if (e.error != null && e.error.toString().contains('SocketException')) {
         throw Failure(
-            message:
-                'Erro de conexão. Verifique sua internet e tente novamente.');
+          message:
+              'Erro de conexão. Verifique sua internet e tente novamente.',
+        );
       }
 
       _logger.error('Repository - Failed to login user', e, s);
-      throw Failure(message: 'Erro ao realizar login');
+      throw Failure(message: errorMessage ?? 'Erro ao realizar login');
     } catch (e, s) {
       _logger.error('Repository - Failed to login user - 2', e, s);
       throw Failure(message: 'Erro ao realizar login - 2');

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,9 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
 import device_info_plus
-import flutter_secure_storage_macos
+import flutter_secure_storage_darwin
 import package_info_plus
 import path_provider_foundation
 import screen_retriever_macos
@@ -17,8 +18,9 @@ import webview_flutter_wkwebview
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
-  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,7 +1,10 @@
 PODS:
+  - connectivity_plus (0.0.1):
+    - FlutterMacOS
   - device_info_plus (0.0.1):
     - FlutterMacOS
-  - flutter_secure_storage_macos (6.1.3):
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - package_info_plus (0.0.1):
@@ -11,11 +14,11 @@ PODS:
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
-  - Sentry/HybridSDK (8.52.1)
-  - sentry_flutter (9.6.0):
+  - Sentry/HybridSDK (8.58.0)
+  - sentry_flutter (9.15.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.52.1)
+    - Sentry/HybridSDK (= 8.58.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -28,8 +31,9 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
+  - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
@@ -45,10 +49,12 @@ SPEC REPOS:
     - Sentry
 
 EXTERNAL SOURCES:
+  connectivity_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
   device_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
-  flutter_secure_storage_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
+  flutter_secure_storage_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin
   FlutterMacOS:
     :path: Flutter/ephemeral
   package_info_plus:
@@ -69,14 +75,15 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
+  connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
-  flutter_secure_storage_macos: 7f45e30f838cf2659862a4e4e3ee1c347c2b3b54
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
-  Sentry: 2cbbe3592f30050c60e916c63c7f5a2fa584005e
-  sentry_flutter: 9b1e3e6934cb7040ffb71383c95a35f73523180c
+  Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
+  sentry_flutter: 8939e491bc1511868118c96cae47d945e6f69798
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
   webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,18 +93,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clarity_flutter:
     dependency: "direct main"
     description:
       name: clarity_flutter
-      sha256: a467fe7f320a68062f9c41fe2ae0ad26b6fb5cfaec955267686f7675790559d9
+      sha256: "5de3d4158c7eaaaa39e92737bfb45996a88fcb2f3c2db56cbae9ba35992bec32"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.7.1"
   clock:
     dependency: transitive
     description:
@@ -129,6 +129,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: transitive
+    description:
+      name: connectivity_plus
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   convert:
     dependency: transitive
     description:
@@ -161,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   device_info_plus:
     dependency: transitive
     description:
@@ -181,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.0"
+    version: "5.9.2"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -205,10 +229,10 @@ packages:
     dependency: "direct main"
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -258,50 +282,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: da922f2aab2d733db7e011a6bcc4a825b844892d4edd6df83ff156b09a9b2e40
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.0.0"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "8878c25136a79def1668c75985e8e193d9d7d095453ec28730da0315dc69aee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.0"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "6a1137df62b84b54261dca582c1c09ea72f4f9a4b2fcee21b025964132d5d0c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.0"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -316,10 +340,10 @@ packages:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: a4292e7cf67193f8e7c1258203104eb2a51ec8b3a04baa14695f4064c144297b
+      sha256: "568d62f0e68666fb5d95519743b3c24a34c7f19d834b0658c46e26d778461f66"
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.0"
+    version: "9.2.1"
   glob:
     dependency: transitive
     description:
@@ -340,10 +364,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: eb059dfe59f08546e9787f895bd01652076f996bcbf485a8609ef990419ad227
+      sha256: "7974313e217a7771557add6ff2238acb63f635317c35fa590d348fb238f00896"
       url: "https://pub.dev"
     source: hosted
-    version: "16.2.1"
+    version: "17.1.0"
   http:
     dependency: transitive
     description:
@@ -392,14 +416,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -412,26 +428,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -444,10 +460,10 @@ packages:
     dependency: "direct main"
     description:
       name: logger
-      sha256: "55d6c23a6c15db14920e037fe7e0dc32e7cdaf3b64b4b25df2d541b5b6b81c0c"
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "2.7.0"
   logging:
     dependency: transitive
     description:
@@ -460,26 +476,42 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
+  memory_info:
+    dependency: transitive
+    description:
+      name: memory_info
+      sha256: "2d2150e070e1ceeb44d9ac3edad3d03d19022c4e0a4ddb08a3f8a494fc41d1c4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
+  memory_info_platform_interface:
+    dependency: transitive
+    description:
+      name: memory_info_platform_interface
+      sha256: "07c5ad0625f9810fb378fabd69a38c19a800865e11433e767804ff9bd84796db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -492,10 +524,10 @@ packages:
     dependency: "direct main"
     description:
       name: mockito
-      sha256: "4feb43bc4eb6c03e832f5fcd637d1abb44b98f9cfa245c58e27382f58859f8f6"
+      sha256: a45d1aa065b796922db7b9e7e7e45f921aed17adf3a8318a1f47097e7e695566
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.1"
+    version: "5.6.3"
   mocktail:
     dependency: "direct main"
     description:
@@ -504,6 +536,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   package_config:
     dependency: transitive
     description:
@@ -516,10 +556,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -628,10 +668,10 @@ packages:
     dependency: "direct main"
     description:
       name: process_run
-      sha256: "6ec839cdd3e6de4685318e7686cd4abb523c3d3a55af0e8d32a12ae19bc66622"
+      sha256: "78b1ed8828fb6a98b3a28452ae6d77546b87065c61297f4f79b31064a18afcc3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "1.3.1+1"
   properties:
     dependency: transitive
     description:
@@ -644,10 +684,10 @@ packages:
     dependency: transitive
     description:
       name: protobuf
-      sha256: de9c9eb2c33f8e933a42932fe1dc504800ca45ebc3d673e6ed7f39754ee4053e
+      sha256: "75ec242d22e950bdcc79ee38dd520ce4ee0bc491d7fadc4ea47694604d22bf06"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "6.0.0"
   pub_semver:
     dependency: transitive
     description:
@@ -700,34 +740,34 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: d9f3dcf1ecdd600cf9ce134f622383adde5423ecfdaf0ca9b20fbc1c44849337
+      sha256: a49b4fb1cba576fe216347dc2a0e6d76076fb998e6012857db96f991c23b7b3c
       url: "https://pub.dev"
     source: hosted
-    version: "9.6.0"
+    version: "9.15.0"
   sentry_dart_plugin:
     dependency: "direct dev"
     description:
       name: sentry_dart_plugin
-      sha256: "8c0c9fe19368890381101f5000759b2ae203a0bf6158a25584b55d197e847f53"
+      sha256: "514cd5cc5c022bed9c232d08dc126a081b8a965dbad78b819ae91bf3a06e622c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.2.1"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "37deb4ef8837d10b5c1f527ec18591f8d2d2da9c34f19b3d97ccbbe7f84077c0"
+      sha256: "25150030c93bd1d4b727ab61cfb09e99121c69ce90fa820bb9ca16dab433e43a"
       url: "https://pub.dev"
     source: hosted
-    version: "9.6.0"
+    version: "9.15.0"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.4"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -780,10 +820,10 @@ packages:
     dependency: "direct main"
     description:
       name: shorebird_code_push
-      sha256: cc78bbf651d320414e6ce66d6f3e825f91050050bf94bbe27f7eb3eebfdfde1c
+      sha256: "82203f39a66c78548da944dbe4079c2aa2a60fa5bc1105ed707b144c94f04349"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -805,14 +845,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
-  sprintf:
-    dependency: transitive
-    description:
-      name: sprintf
-      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -865,10 +897,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -945,26 +977,26 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.1"
+    version: "4.5.3"
   validatorless:
     dependency: "direct main"
     description:
       name: validatorless
-      sha256: cba8b7e315bc59bef31aa84bdabe8382f606e5cfc777cab14fdbd55dba0a97a3
+      sha256: c1c4c15c84b81edfbe90e497a4517ce4c2d45a4b40544ec3ebbd91448f0f9a03
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "1.2.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1009,10 +1041,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
+      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
       url: "https://pub.dev"
     source: hosted
-    version: "4.13.0"
+    version: "4.13.1"
   webview_flutter_android:
     dependency: transitive
     description:
@@ -1094,5 +1126,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,44 +5,44 @@ publish_to: 'none'
 version: 1.0.14+4
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   ###
   asuka: ^2.2.1
 
-  clarity_flutter: ^1.4.0
+  clarity_flutter: ^1.7.1
   cupertino_icons: ^1.0.8
-  dio: ^5.9.0
-  ffi: ^2.1.3
+  dio: ^5.9.2
+  ffi: ^2.2.0
   flutter:
     sdk: flutter
   flutter_dotenv: ^6.0.0
   flutter_screenutil: ^5.9.3
-  flutter_secure_storage: ^9.2.4
-  get_it: ^8.2.0
-  go_router: ^16.2.1
+  flutter_secure_storage: ^10.0.0
+  get_it: ^9.2.1
+  go_router: ^17.1.0
   intl: ^0.20.2
-  logger: ^2.6.1
-  mockito: ^5.5.1
+  logger: ^2.7.0
+  mockito: ^5.6.3
   mocktail: ^1.0.4
-  package_info_plus: ^8.3.1
-  process_run: ^1.2.4
-  sentry_flutter: ^9.6.0
-  shared_preferences: ^2.5.3
-  shorebird_code_push: ^2.0.4
+  package_info_plus: ^9.0.0
+  process_run: ^1.3.1
+  sentry_flutter: ^9.15.0
+  shared_preferences: ^2.5.4
+  shorebird_code_push: ^2.0.5
   url_launcher: ^6.3.2
-  uuid: ^4.5.1
-  validatorless: ^1.2.3
+  uuid: ^4.5.3
+  validatorless: ^1.2.5
   web_socket_channel: ^3.0.3
-  
+
   webview_windows: ^0.4.0
-  webview_flutter: ^4.13.0
+  webview_flutter: ^4.13.1
   win32: ^5.14.0
   window_manager: ^0.5.1
 
 dev_dependencies:
-  sentry_dart_plugin: ^3.1.1
+  sentry_dart_plugin: ^3.2.1
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
@@ -14,6 +15,8 @@
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   flutter_secure_storage_windows
   screen_retriever_windows
   sentry_flutter


### PR DESCRIPTION
## Summary
- Configure ScreenUtil for desktop with 1366x768 design size and responsive breakpoints
- Fix infinite snackbar loop on register/login command listeners
- Handle 404 status on login to show correct API error message
- Fix schedule list endpoint returning List instead of Map
- Update dependencies and analysis options

## Changes
- **ScreenUtil**: initialized with `1366x768` designSize, window minimum size enforced
- **Responsive breakpoints**: tablet (720px), desktop (1366px), desktopLarge (1920px)
- **Login page**: added handled flags to prevent re-triggering command listeners on rebuild
- **Login error**: now handles 404/401 status codes with proper user-facing messages
- **Schedule list**: handles both `List` and `Map` response formats from API
- **SecureStorage**: simplified initialization removing deprecated Android options