### PR TITLE
feat: add score module with calendar grid and filters

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,7 @@
 include: package:flutter_lints/flutter.yaml
 
 formatter:
-  preserve-trailing-commas: true
+  trailing_commas: preserve
 
 analyzer:
   errors:

--- a/lib/core/app/weblurk_app.dart
+++ b/lib/core/app/weblurk_app.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../controllers/update_controller.dart';
+import '../routes/router_config.dart';
+import '../services/shorebird_update_service.dart';
+import '../ui/ui_config.dart';
+import '../ui/widgets/android_back_button_handler.dart';
+
+class Weblurk extends StatefulWidget {
+  const Weblurk({super.key});
+
+  @override
+  State<Weblurk> createState() => _WeblurklState();
+}
+
+class _WeblurklState extends State<Weblurk> {
+  @override
+  void initState() {
+    super.initState();
+    _checkForUpdates();
+  }
+
+  Future<void> _checkForUpdates() async {
+    await Future.delayed(const Duration(seconds: 2));
+
+    final updateService = ShorebirdUpdateService();
+    await updateService.debugShorebird();
+
+    final hasUpdate = await updateService.checkForUpdates();
+    if (hasUpdate && mounted) {
+      final updateController = UpdateController();
+      await updateController.checkAndShowUpdateDialog(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScreenUtilInit(
+      designSize: const Size(1366, 768),
+      minTextAdapt: true,
+      splitScreenMode: true,
+      builder: (context, child) {
+        return AndroidBackButtonHandler(
+          child: MaterialApp.router(
+            routerConfig: AppRouter.router,
+            title: UiConfig.title,
+            theme: UiConfig.theme,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/core/di/injector.dart
+++ b/lib/core/di/injector.dart
@@ -7,6 +7,11 @@ import '../../features/auth/register/presentation/viewmodels/register_viewmodel.
 import '../../features/home/data/services/polling_services.dart';
 import '../../features/home/data/services/webview_service.dart';
 import '../../features/home/presentation/viewmodels/home_viewmodel.dart';
+import '../../features/score/data/repositories/score_repository.dart';
+import '../../features/score/data/repositories/score_repository_impl.dart';
+import '../../features/score/data/services/score_service.dart';
+import '../../features/score/data/services/score_service_impl.dart';
+import '../../features/score/presentation/viewmodels/score_viewmodel.dart';
 import '../../repositories/home/home_repository.dart';
 import '../../repositories/home/home_repository_impl.dart';
 import '../../repositories/schedule/schedule_repository.dart';
@@ -94,6 +99,13 @@ class Injector {
         logger: i(),
       ),
     );
+
+    i.registerLazySingleton<ScoreRepository>(
+      () => ScoreRepositoryImpl(
+        restClient: i(),
+        logger: i(),
+      ),
+    );
   }
 
   static Future<void> _injectServices() async {
@@ -160,6 +172,14 @@ class Injector {
         logger: i(),
       ),
     );
+
+    i.registerLazySingleton<ScoreService>(
+      () => ScoreServiceImpl(
+        repository: i(),
+        authViewModel: i(),
+        logger: i(),
+      ),
+    );
   }
 
   static Future<void> _injectControllers() async {
@@ -173,6 +193,12 @@ class Injector {
     i.registerFactory<RegisterViewModel>(
       () => RegisterViewModel(
         userService: i(),
+      ),
+    );
+
+    i.registerLazySingleton<ScoreViewModel>(
+      () => ScoreViewModel(
+        scoreService: i(),
       ),
     );
 

--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -3,4 +3,5 @@ class AppRoutes {
   static const String login = '/login';
   static const String register = '/register';
   static const String home = '/home';
+  static const String score = '/score';
 }

--- a/lib/core/routes/router_config.dart
+++ b/lib/core/routes/router_config.dart
@@ -6,31 +6,43 @@ import '../../features/auth/login/presentation/viewmodels/auth_viewmodel.dart';
 import '../../features/auth/login/presentation/viewmodels/login_viewmodel.dart';
 import '../../features/home/presentation/pages/home_page.dart';
 import '../../features/home/presentation/viewmodels/home_viewmodel.dart';
+import '../../features/score/presentation/pages/score_page.dart';
+import '../../features/score/presentation/viewmodels/score_viewmodel.dart';
+import '../../features/splash/presentation/pages/splash_page.dart';
 import '../di/injector.dart';
 import '../logger/app_logger.dart';
 import '../services/navigation_service.dart';
 import 'app_routes.dart';
 
 class AppRouter {
-  static GoRouter get router => GoRouter(
-        navigatorKey: NavigationService.navigatorKey,
-        redirect: (context, state) => _redirect(context, state, injector()),
-        refreshListenable: injector<AuthViewModel>(),
-        initialLocation: AppRoutes.login,
-        routes: [
-          GoRoute(
-            path: AppRoutes.splash,
-            builder: (context, state) => const SplashPage(),
+  static final GoRouter router = GoRouter(
+    navigatorKey: NavigationService.navigatorKey,
+    redirect: (context, state) => _redirect(
+      context,
+      state,
+      injector(),
+    ),
+    refreshListenable: injector<AuthViewModel>(),
+    initialLocation: AppRoutes.login,
+    routes: [
+      GoRoute(
+        path: AppRoutes.splash,
+        builder: (context, state) => const SplashPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.login,
+        pageBuilder: (context, state) => CustomTransitionPage(
+          key: state.pageKey,
+          child: LoginPage(
+            viewModel: injector<LoginViewModel>(),
           ),
-          GoRoute(
-            path: AppRoutes.login,
-            pageBuilder: (context, state) => CustomTransitionPage(
-              key: state.pageKey,
-              child: LoginPage(
-                viewModel: injector<LoginViewModel>(),
-              ),
-              transitionsBuilder:
-                  (context, animation, secondaryAnimation, child) {
+          transitionsBuilder:
+              (
+                context,
+                animation,
+                secondaryAnimation,
+                child,
+              ) {
                 return FadeTransition(
                   opacity: animation,
                   child: SlideTransition(
@@ -39,9 +51,7 @@ class AppRouter {
                         begin: const Offset(0.0, 0.3),
                         end: Offset.zero,
                       ).chain(
-                        CurveTween(
-                          curve: Curves.easeOutCubic,
-                        ),
+                        CurveTween(curve: Curves.easeOutCubic),
                       ),
                     ),
                     child: ScaleTransition(
@@ -50,9 +60,7 @@ class AppRouter {
                           begin: 0.8,
                           end: 1.0,
                         ).chain(
-                          CurveTween(
-                            curve: Curves.easeOutCubic,
-                          ),
+                          CurveTween(curve: Curves.easeOutCubic),
                         ),
                       ),
                       child: child,
@@ -60,16 +68,22 @@ class AppRouter {
                   ),
                 );
               },
-            ),
-          ),
-          GoRoute(
-            path: AppRoutes.home,
-            builder: (context, state) => HomePage(
-              viewModel: injector<HomeViewModel>(),
-            ),
-          ),
-        ],
-      );
+        ),
+      ),
+      GoRoute(
+        path: AppRoutes.home,
+        builder: (context, state) => HomePage(
+          viewModel: injector<HomeViewModel>(),
+        ),
+      ),
+      GoRoute(
+        path: AppRoutes.score,
+        builder: (context, state) => ScorePage(
+          viewModel: injector<ScoreViewModel>(),
+        ),
+      ),
+    ],
+  );
 
   static Future<String?> _redirect(
     BuildContext context,
@@ -97,18 +111,5 @@ class AppRouter {
       return AppRoutes.home;
     }
     return null;
-  }
-}
-
-class SplashPage extends StatelessWidget {
-  const SplashPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: CircularProgressIndicator(),
-      ),
-    );
   }
 }

--- a/lib/core/ui/widgets/combined_menu_button.dart
+++ b/lib/core/ui/widgets/combined_menu_button.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../features/home/presentation/viewmodels/home_viewmodel.dart';
+import '../../routes/app_routes.dart';
 import '../../services/settings_service.dart';
 import '../../services/timezone_service.dart';
 import '../../services/url_launcher_service.dart';
@@ -271,10 +273,8 @@ class _CombinedMenuButtonState extends State<CombinedMenuButton> {
           label: 'Pontuação',
           icon: Icons.leaderboard,
           iconColor: AppColors.menuIconWarning,
-          onTap: () async {
-            await widget.urlLauncherService.launchURL(
-              'https://docs.google.com/spreadsheets/d/1kh4zc2INhLEOGbLqqte8NnP4NsNRvFTgSWvKNKKM9qk/edit?usp=sharing',
-            );
+          onTap: () {
+            context.push(AppRoutes.score);
           },
         ),
         MenuItemWidget(

--- a/lib/features/auth/login/presentation/viewmodels/auth_viewmodel.dart
+++ b/lib/features/auth/login/presentation/viewmodels/auth_viewmodel.dart
@@ -18,19 +18,11 @@ class AuthViewModel extends ChangeNotifier {
   final LocalStorage _localStorage;
   final AppLogger _logger;
 
-  static bool _hasInitialized = false;
-
   UserModel? _userLogged;
   UserModel? get userLogged => _userLogged;
 
   Future<void> _loadUserLogged() async {
     try {
-      if (!_hasInitialized) {
-        _hasInitialized = true;
-        await logout();
-        return;
-      }
-
       final userModelJson = await _localStorage.read<String>(
         Constants.LOCAL_SOTRAGE_USER_LOGGED_DATA_KEY,
       );

--- a/lib/features/score/data/repositories/score_repository.dart
+++ b/lib/features/score/data/repositories/score_repository.dart
@@ -1,0 +1,13 @@
+import '../../domain/entities/score_entry_model.dart';
+
+abstract interface class ScoreRepository {
+  Future<List<ScoreEntryModel>> fetchScores({DateTime? date});
+
+  Future<List<ScoreEntryModel>> fetchScoresWithFilters({
+    String? nickname,
+    DateTime? startDate,
+    DateTime? endDate,
+    int? startHour,
+    int? endHour,
+  });
+}

--- a/lib/features/score/data/repositories/score_repository_impl.dart
+++ b/lib/features/score/data/repositories/score_repository_impl.dart
@@ -1,0 +1,86 @@
+import '../../../../core/exceptions/failure.dart';
+import '../../../../core/logger/app_logger.dart';
+import '../../../../core/rest_client/rest_client.dart';
+import '../../../../core/rest_client/rest_client_exception.dart';
+import '../../domain/entities/score_entry_model.dart';
+import 'score_repository.dart';
+
+class ScoreRepositoryImpl implements ScoreRepository {
+  final RestClient _restClient;
+  final AppLogger _logger;
+
+  ScoreRepositoryImpl({
+    required RestClient restClient,
+    required AppLogger logger,
+  })  : _restClient = restClient,
+        _logger = logger;
+
+  @override
+  Future<List<ScoreEntryModel>> fetchScores({DateTime? date}) async {
+    try {
+      final queryParams = <String, dynamic>{};
+      if (date != null) {
+        queryParams['date'] = _formatDate(date);
+      }
+
+      final response = await _restClient.auth().get(
+            '/score',
+            queryParameters: queryParams,
+          );
+
+      if (response.data is List) {
+        return (response.data as List)
+            .map((e) => ScoreEntryModel.fromMap(e as Map<String, dynamic>))
+            .toList();
+      }
+
+      return [];
+    } on RestClientException catch (e, s) {
+      _logger.error('Failed to fetch scores', e, s);
+      throw Failure(message: 'Erro ao buscar pontuação');
+    } catch (e, s) {
+      _logger.error('Unexpected error fetching scores', e, s);
+      throw Failure(message: 'Erro inesperado ao buscar pontuação');
+    }
+  }
+
+  @override
+  Future<List<ScoreEntryModel>> fetchScoresWithFilters({
+    String? nickname,
+    DateTime? startDate,
+    DateTime? endDate,
+    int? startHour,
+    int? endHour,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{};
+      if (nickname != null) queryParams['nickname'] = nickname;
+      if (startDate != null) queryParams['startDate'] = _formatDate(startDate);
+      if (endDate != null) queryParams['endDate'] = _formatDate(endDate);
+      if (startHour != null) queryParams['startHour'] = startHour.toString();
+      if (endHour != null) queryParams['endHour'] = endHour.toString();
+
+      final response = await _restClient.auth().get(
+            '/public/score',
+            queryParameters: queryParams,
+          );
+
+      if (response.data is List) {
+        return (response.data as List)
+            .map((e) => ScoreEntryModel.fromMap(e as Map<String, dynamic>))
+            .toList();
+      }
+
+      return [];
+    } on RestClientException catch (e, s) {
+      _logger.error('Failed to fetch scores with filters', e, s);
+      throw Failure(message: 'Erro ao buscar pontuação com filtros');
+    } catch (e, s) {
+      _logger.error('Unexpected error fetching scores with filters', e, s);
+      throw Failure(message: 'Erro inesperado ao buscar pontuação');
+    }
+  }
+
+  String _formatDate(DateTime date) =>
+      '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+}

--- a/lib/features/score/data/services/score_service.dart
+++ b/lib/features/score/data/services/score_service.dart
@@ -1,0 +1,16 @@
+import '../../domain/entities/score_entry_model.dart';
+import '../../domain/entities/score_summary_model.dart';
+
+abstract interface class ScoreService {
+  Future<List<ScoreEntryModel>> getMyScores({DateTime? date});
+
+  Future<List<ScoreEntryModel>> getMyScoresByRange({
+    required DateTime startDate,
+    required DateTime endDate,
+  });
+
+  Future<ScoreSummaryModel> getMySummary({
+    required DateTime startDate,
+    required DateTime endDate,
+  });
+}

--- a/lib/features/score/data/services/score_service_impl.dart
+++ b/lib/features/score/data/services/score_service_impl.dart
@@ -1,0 +1,81 @@
+import '../../../../core/logger/app_logger.dart';
+import '../../../../models/user_model.dart';
+import '../../../auth/login/presentation/viewmodels/auth_viewmodel.dart';
+import '../../domain/entities/score_entry_model.dart';
+import '../../domain/entities/score_summary_model.dart';
+import '../repositories/score_repository.dart';
+import 'score_service.dart';
+
+class ScoreServiceImpl implements ScoreService {
+  final ScoreRepository _repository;
+  final AuthViewModel _authViewModel;
+  final AppLogger _logger;
+
+  ScoreServiceImpl({
+    required ScoreRepository repository,
+    required AuthViewModel authViewModel,
+    required AppLogger logger,
+  })  : _repository = repository,
+        _authViewModel = authViewModel,
+        _logger = logger;
+
+  UserModel? get _currentUser => _authViewModel.userLogged;
+
+  @override
+  Future<List<ScoreEntryModel>> getMyScores({DateTime? date}) async {
+    final user = _currentUser;
+    if (user == null) {
+      _logger.warning('No user logged in to fetch scores');
+      return [];
+    }
+
+    final scores = await _repository.fetchScores(date: date);
+    return scores
+        .where((s) => s.nickname == user.nickname)
+        .toList();
+  }
+
+  @override
+  Future<List<ScoreEntryModel>> getMyScoresByRange({
+    required DateTime startDate,
+    required DateTime endDate,
+  }) async {
+    final user = _currentUser;
+    if (user == null) {
+      _logger.warning('No user logged in to fetch scores');
+      return [];
+    }
+
+    return _repository.fetchScoresWithFilters(
+      nickname: user.nickname,
+      startDate: startDate,
+      endDate: endDate,
+    );
+  }
+
+  @override
+  Future<ScoreSummaryModel> getMySummary({
+    required DateTime startDate,
+    required DateTime endDate,
+  }) async {
+    final scores = await getMyScoresByRange(
+      startDate: startDate,
+      endDate: endDate,
+    );
+
+    final pointsByDate = <String, int>{};
+    var totalPoints = 0;
+
+    for (final score in scores) {
+      totalPoints += score.points;
+      final dateKey = score.formattedDate;
+      pointsByDate[dateKey] = (pointsByDate[dateKey] ?? 0) + score.points;
+    }
+
+    return ScoreSummaryModel(
+      totalPoints: totalPoints,
+      totalEntries: scores.length,
+      pointsByDate: pointsByDate,
+    );
+  }
+}

--- a/lib/features/score/domain/entities/date_range_filter.dart
+++ b/lib/features/score/domain/entities/date_range_filter.dart
@@ -1,0 +1,44 @@
+enum DateRangeFilter {
+  today('Hoje'),
+  week('Semana'),
+  month('Mês');
+
+  const DateRangeFilter(this.label);
+  final String label;
+
+  ({DateTime start, DateTime end}) toDateRange(DateTime reference) {
+    return switch (this) {
+      DateRangeFilter.today => (
+        start: DateTime(
+          reference.year,
+          reference.month,
+          reference.day,
+        ),
+        end: DateTime(
+          reference.year,
+          reference.month,
+          reference.day,
+        ),
+      ),
+      DateRangeFilter.week => (
+        start: reference.subtract(
+          Duration(days: reference.weekday - 1),
+        ),
+        end: reference.add(
+          Duration(days: 7 - reference.weekday),
+        ),
+      ),
+      DateRangeFilter.month => (
+        start: DateTime(
+          reference.year,
+          reference.month,
+        ),
+        end: DateTime(
+          reference.year,
+          reference.month + 1,
+          0,
+        ),
+      ),
+    };
+  }
+}

--- a/lib/features/score/domain/entities/score_entry_model.dart
+++ b/lib/features/score/domain/entities/score_entry_model.dart
@@ -1,0 +1,39 @@
+class ScoreEntryModel {
+  final int id;
+  final int streamerId;
+  final DateTime date;
+  final int hour;
+  final int minute;
+  final int points;
+  final String nickname;
+
+  const ScoreEntryModel({
+    required this.id,
+    required this.streamerId,
+    required this.date,
+    required this.hour,
+    required this.minute,
+    required this.points,
+    required this.nickname,
+  });
+
+  factory ScoreEntryModel.fromMap(Map<String, dynamic> map) {
+    return ScoreEntryModel(
+      id: map['id'] as int? ?? 0,
+      streamerId: map['streamerId'] as int? ?? 0,
+      date: map['date'] != null
+          ? DateTime.parse(map['date'] as String)
+          : DateTime.now(),
+      hour: map['hour'] as int? ?? 0,
+      minute: map['minute'] as int? ?? 0,
+      points: map['points'] as int? ?? 0,
+      nickname: map['nickname'] as String? ?? '',
+    );
+  }
+
+  String get formattedTime =>
+      '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
+
+  String get formattedDate =>
+      '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}/${date.year}';
+}

--- a/lib/features/score/domain/entities/score_summary_model.dart
+++ b/lib/features/score/domain/entities/score_summary_model.dart
@@ -1,0 +1,11 @@
+class ScoreSummaryModel {
+  final int totalPoints;
+  final int totalEntries;
+  final Map<String, int> pointsByDate;
+
+  const ScoreSummaryModel({
+    required this.totalPoints,
+    required this.totalEntries,
+    required this.pointsByDate,
+  });
+}

--- a/lib/features/score/domain/entities/score_week_day_model.dart
+++ b/lib/features/score/domain/entities/score_week_day_model.dart
@@ -1,0 +1,15 @@
+class ScoreWeekDayModel {
+  final DateTime date;
+  final String dayNumber;
+  final int points;
+  final bool isToday;
+  final bool isCurrentMonth;
+
+  const ScoreWeekDayModel({
+    required this.date,
+    required this.dayNumber,
+    required this.points,
+    required this.isToday,
+    required this.isCurrentMonth,
+  });
+}

--- a/lib/features/score/presentation/pages/score_page.dart
+++ b/lib/features/score/presentation/pages/score_page.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+import '../../domain/entities/date_range_filter.dart';
+import '../viewmodels/score_viewmodel.dart';
+import '../widgets/score_calendar_grid.dart';
+import '../widgets/score_filter_bar.dart';
+import '../widgets/score_list_section.dart';
+import '../widgets/score_summary_card.dart';
+
+class ScorePage extends StatefulWidget {
+  const ScorePage({super.key, required this.viewModel});
+
+  final ScoreViewModel viewModel;
+
+  @override
+  State<ScorePage> createState() => _ScorePageState();
+}
+
+class _ScorePageState extends State<ScorePage> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.viewModel.scores.isEmpty &&
+        !widget.viewModel.loadScoresCommand.running) {
+      widget.viewModel.loadAll();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: const Text(
+          'Minha Pontuação',
+          style: TextStyle(
+            fontFamily: 'Ibrand',
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        backgroundColor: AppColors.cosmicDarkPurple,
+        iconTheme: const IconThemeData(color: Colors.white),
+        elevation: 0,
+        actions: [
+          IconButton(
+            onPressed: widget.viewModel.loadAll,
+            icon: const Icon(Icons.refresh, color: Colors.white),
+            tooltip: 'Atualizar',
+          ),
+        ],
+      ),
+      body: ListenableBuilder(
+        listenable: Listenable.merge([
+          widget.viewModel.loadScoresCommand,
+          widget.viewModel.loadSummaryCommand,
+          widget.viewModel,
+        ]),
+        builder: (context, _) {
+          final isLoading =
+              widget.viewModel.loadScoresCommand.running ||
+              widget.viewModel.loadSummaryCommand.running;
+
+          return Column(
+            children: [
+              ScoreFilterBar(
+                selectedDate: widget.viewModel.selectedDate,
+                selectedFilter: widget.viewModel.rangeFilter,
+                onDateTap: () => _showDatePicker(context),
+                onFilterSelected: widget.viewModel.changeRangeFilter,
+              ),
+              Expanded(
+                child: isLoading
+                    ? const Center(
+                        child: CircularProgressIndicator(
+                          color: AppColors.accent,
+                        ),
+                      )
+                    : SingleChildScrollView(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            ScoreSummaryCard(
+                              summary: widget.viewModel.summary,
+                            ),
+                            if (widget.viewModel.calendarWeeks.isNotEmpty) ...[
+                              const SizedBox(height: 16),
+                              ScoreCalendarGrid(
+                                weeks: widget.viewModel.calendarWeeks,
+                                dateRangeLabel:
+                                    widget.viewModel.dateRangeLabel,
+                              ),
+                            ],
+                            if (widget.viewModel.rangeFilter ==
+                                DateRangeFilter.today) ...[
+                              const SizedBox(height: 16),
+                              ScoreListSection(
+                                scores: widget.viewModel.scores,
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _showDatePicker(BuildContext context) async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: widget.viewModel.selectedDate,
+      firstDate: DateTime(2024),
+      lastDate: DateTime.now(),
+      builder: (context, child) {
+        return Theme(
+          data: Theme.of(context).copyWith(
+            colorScheme: const ColorScheme.dark(
+              primary: AppColors.accent,
+              surface: AppColors.cosmicDarkPurple,
+            ),
+          ),
+          child: child!,
+        );
+      },
+    );
+
+    if (picked != null) {
+      widget.viewModel.changeDate(picked);
+    }
+  }
+}

--- a/lib/features/score/presentation/viewmodels/score_viewmodel.dart
+++ b/lib/features/score/presentation/viewmodels/score_viewmodel.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:intl/intl.dart';
+
+import '../../../../core/helpers/sentry_mixin.dart';
+import '../../../../core/utils/command.dart';
+import '../../../../core/utils/result.dart';
+import '../../data/services/score_service.dart';
+import '../../domain/entities/date_range_filter.dart';
+import '../../domain/entities/score_entry_model.dart';
+import '../../domain/entities/score_summary_model.dart';
+import '../../domain/entities/score_week_day_model.dart';
+
+class ScoreViewModel extends ChangeNotifier with SentryMixin {
+  ScoreViewModel({required ScoreService scoreService})
+    : _scoreService = scoreService;
+
+  final ScoreService _scoreService;
+
+  List<ScoreEntryModel> _scores = [];
+  List<ScoreEntryModel> get scores => _scores;
+
+  ScoreSummaryModel? _summary;
+  ScoreSummaryModel? get summary => _summary;
+
+  DateTime _selectedDate = DateTime.now();
+  DateTime get selectedDate => _selectedDate;
+
+  DateRangeFilter _rangeFilter = DateRangeFilter.today;
+  DateRangeFilter get rangeFilter => _rangeFilter;
+
+  List<List<ScoreWeekDayModel>> get calendarWeeks => _buildCalendarWeeks();
+
+  String get dateRangeLabel => _buildDateRangeLabel();
+
+  late final loadScoresCommand = Command0<List<ScoreEntryModel>>(
+    () => _loadScores(),
+  );
+
+  late final loadSummaryCommand = Command0<ScoreSummaryModel>(
+    () => _loadSummary(),
+  );
+
+  Future<Result<List<ScoreEntryModel>>> _loadScores() async {
+    try {
+      final range = _rangeFilter.toDateRange(_selectedDate);
+      final scores = await _scoreService.getMyScoresByRange(
+        startDate: range.start,
+        endDate: range.end,
+      );
+
+      _scores = scores;
+      notifyListeners();
+
+      return Result.ok(scores);
+    } catch (e) {
+      await captureError(e, StackTrace.current, context: 'load_scores');
+      return Result.error(Exception('Erro ao carregar pontuação'));
+    }
+  }
+
+  Future<Result<ScoreSummaryModel>> _loadSummary() async {
+    try {
+      final range = _rangeFilter.toDateRange(_selectedDate);
+      final summary = await _scoreService.getMySummary(
+        startDate: range.start,
+        endDate: range.end,
+      );
+
+      _summary = summary;
+      notifyListeners();
+
+      return Result.ok(summary);
+    } catch (e) {
+      await captureError(e, StackTrace.current, context: 'load_summary');
+      return Result.error(Exception('Erro ao carregar resumo'));
+    }
+  }
+
+  void changeDate(DateTime date) {
+    _selectedDate = date;
+    notifyListeners();
+    loadScoresCommand.execute();
+    loadSummaryCommand.execute();
+  }
+
+  void changeRangeFilter(DateRangeFilter filter) {
+    _rangeFilter = filter;
+    notifyListeners();
+    loadScoresCommand.execute();
+    loadSummaryCommand.execute();
+  }
+
+  void loadAll() {
+    loadScoresCommand.execute();
+    loadSummaryCommand.execute();
+  }
+
+  Map<String, int> get _pointsByDay {
+    final map = <String, int>{};
+    for (final score in _scores) {
+      final key = DateFormat('yyyy-MM-dd').format(score.date);
+      map[key] = (map[key] ?? 0) + score.points;
+    }
+    return map;
+  }
+
+  List<List<ScoreWeekDayModel>> _buildCalendarWeeks() {
+    if (_rangeFilter == DateRangeFilter.today) return [];
+
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final pointsMap = _pointsByDay;
+    final range = _rangeFilter.toDateRange(_selectedDate);
+
+    final DateTime gridStart;
+    final int totalWeeks;
+
+    if (_rangeFilter == DateRangeFilter.week) {
+      gridStart = range.start;
+      totalWeeks = 1;
+    } else {
+      final monthStart = DateTime(range.start.year, range.start.month);
+      final weekdayOffset = (monthStart.weekday - 1) % 7;
+      gridStart = monthStart.subtract(
+        Duration(days: weekdayOffset),
+      );
+      totalWeeks = 4;
+    }
+
+    final weeks = <List<ScoreWeekDayModel>>[];
+
+    for (var w = 0; w < totalWeeks; w++) {
+      final week = <ScoreWeekDayModel>[];
+      for (var d = 0; d < 7; d++) {
+        final date = gridStart.add(Duration(days: w * 7 + d));
+        final dateKey = DateFormat('yyyy-MM-dd').format(date);
+        final dayDate = DateTime(date.year, date.month, date.day);
+
+        week.add(
+          ScoreWeekDayModel(
+            date: date,
+            dayNumber: date.day.toString().padLeft(2, '0'),
+            points: pointsMap[dateKey] ?? 0,
+            isToday: dayDate == today,
+            isCurrentMonth: date.month == _selectedDate.month,
+          ),
+        );
+      }
+      weeks.add(week);
+    }
+
+    return weeks;
+  }
+
+  String _buildDateRangeLabel() {
+    final range = _rangeFilter.toDateRange(_selectedDate);
+    final fmt = DateFormat('dd/MM/yyyy');
+
+    if (_rangeFilter == DateRangeFilter.today) {
+      return fmt.format(range.start);
+    }
+
+    if (_rangeFilter == DateRangeFilter.week) {
+      return '${fmt.format(range.start)} - ${fmt.format(range.end)}';
+    }
+
+    final monthStart = DateTime(range.start.year, range.start.month);
+    final weekdayOffset = (monthStart.weekday - 1) % 7;
+    final gridStart = monthStart.subtract(
+      Duration(days: weekdayOffset),
+    );
+    final gridEnd = gridStart.add(
+      const Duration(days: 27),
+    );
+    return '${fmt.format(gridStart)} - ${fmt.format(gridEnd)}';
+  }
+}

--- a/lib/features/score/presentation/widgets/score_calendar_grid.dart
+++ b/lib/features/score/presentation/widgets/score_calendar_grid.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+import '../../domain/entities/score_week_day_model.dart';
+import 'score_week_row.dart';
+
+class ScoreCalendarGrid extends StatelessWidget {
+  const ScoreCalendarGrid({
+    super.key,
+    required this.weeks,
+    required this.dateRangeLabel,
+  });
+
+  final List<List<ScoreWeekDayModel>> weeks;
+  final String dateRangeLabel;
+
+  static const _dayHeaders = ['Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom'];
+
+  @override
+  Widget build(BuildContext context) {
+    if (weeks.isEmpty) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.cosmicDarkPurple,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.cosmicBorder.withValues(alpha: 0.5),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            dateRangeLabel,
+            style: const TextStyle(
+              color: Colors.white70,
+              fontSize: 13,
+              fontFamily: 'Ibrand',
+              letterSpacing: 0.5,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: _dayHeaders
+                .map(
+                  (h) => Expanded(
+                    child: Text(
+                      h,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.white54,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        fontFamily: 'Ibrand',
+                        letterSpacing: 0.5,
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+          const SizedBox(height: 8),
+          ...weeks.map(
+            (week) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: ScoreWeekRow(days: week),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_date_selector.dart
+++ b/lib/features/score/presentation/widgets/score_date_selector.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/ui/app_colors.dart';
+
+class ScoreDateSelector extends StatelessWidget {
+  const ScoreDateSelector({
+    super.key,
+    required this.selectedDate,
+    required this.onTap,
+  });
+
+  final DateTime selectedDate;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          border: Border.all(color: AppColors.cosmicBorder),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.calendar_today,
+              color: Colors.white70,
+              size: 16,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              DateFormat('dd/MM/yyyy').format(selectedDate),
+              style: const TextStyle(
+                color: Colors.white,
+                fontFamily: 'Ibrand',
+                fontSize: 16,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_empty_state.dart
+++ b/lib/features/score/presentation/widgets/score_empty_state.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+
+class ScoreEmptyState extends StatelessWidget {
+  const ScoreEmptyState({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(32),
+      decoration: BoxDecoration(
+        color: AppColors.cosmicDarkPurple,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.cosmicBorder.withValues(alpha: 0.5),
+        ),
+      ),
+      child: const Column(
+        children: [
+          Icon(
+            Icons.emoji_events_outlined,
+            color: Colors.white38,
+            size: 48,
+          ),
+          SizedBox(height: 12),
+          Text(
+            'Nenhuma pontuação encontrada',
+            style: TextStyle(
+              color: Colors.white54,
+              fontSize: 16,
+              fontFamily: 'Ibrand',
+            ),
+          ),
+          SizedBox(height: 4),
+          Text(
+            'Sua pontuação aparecerá aqui quando houver registros',
+            style: TextStyle(
+              color: Colors.white38,
+              fontSize: 13,
+              fontFamily: 'Ibrand',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_filter_bar.dart
+++ b/lib/features/score/presentation/widgets/score_filter_bar.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+import '../../domain/entities/date_range_filter.dart';
+import 'score_date_selector.dart';
+import 'score_range_chip.dart';
+
+class ScoreFilterBar extends StatelessWidget {
+  const ScoreFilterBar({
+    super.key,
+    required this.selectedDate,
+    required this.selectedFilter,
+    required this.onDateTap,
+    required this.onFilterSelected,
+  });
+
+  final DateTime selectedDate;
+  final DateRangeFilter selectedFilter;
+  final VoidCallback onDateTap;
+  final ValueChanged<DateRangeFilter> onFilterSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: const BoxDecoration(
+        color: AppColors.cosmicDarkPurple,
+        border: Border(
+          bottom: BorderSide(color: AppColors.cosmicBorder),
+        ),
+      ),
+      child: Row(
+        children: [
+          ScoreDateSelector(
+            selectedDate: selectedDate,
+            onTap: onDateTap,
+          ),
+          const SizedBox(width: 16),
+          ...DateRangeFilter.values.map(
+            (filter) => Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: ScoreRangeChip(
+                filter: filter,
+                isSelected: selectedFilter == filter,
+                onSelected: () => onFilterSelected(filter),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_list_header.dart
+++ b/lib/features/score/presentation/widgets/score_list_header.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+
+class ScoreListHeader extends StatelessWidget {
+  const ScoreListHeader({super.key, required this.totalEntries});
+
+  final int totalEntries;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.emoji_events,
+            color: AppColors.cosmicAccent,
+            size: 20,
+          ),
+          const SizedBox(width: 8),
+          Text(
+            'Histórico ($totalEntries registros)',
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              fontFamily: 'Ibrand',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_list_section.dart
+++ b/lib/features/score/presentation/widgets/score_list_section.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+import '../../domain/entities/score_entry_model.dart';
+import 'score_empty_state.dart';
+import 'score_list_header.dart';
+import 'score_row_item.dart';
+
+class ScoreListSection extends StatelessWidget {
+  const ScoreListSection({super.key, required this.scores});
+
+  final List<ScoreEntryModel> scores;
+
+  @override
+  Widget build(BuildContext context) {
+    if (scores.isEmpty) {
+      return const ScoreEmptyState();
+    }
+
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.cosmicDarkPurple,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.cosmicBorder.withValues(alpha: 0.5),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ScoreListHeader(totalEntries: scores.length),
+          const Divider(
+            color: AppColors.cosmicBorder,
+            height: 1,
+          ),
+          ...scores.map(
+            (score) => ScoreRowItem(score: score),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_range_chip.dart
+++ b/lib/features/score/presentation/widgets/score_range_chip.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+import '../../domain/entities/date_range_filter.dart';
+
+class ScoreRangeChip extends StatelessWidget {
+  const ScoreRangeChip({
+    super.key,
+    required this.filter,
+    required this.isSelected,
+    required this.onSelected,
+  });
+
+  final DateRangeFilter filter;
+  final bool isSelected;
+  final VoidCallback onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChoiceChip(
+      label: Text(
+        filter.label,
+        style: TextStyle(
+          color: isSelected ? Colors.white : Colors.white70,
+          fontFamily: 'Ibrand',
+          fontSize: 16,
+        ),
+      ),
+      selected: isSelected,
+      selectedColor: AppColors.accent,
+      checkmarkColor: Colors.white,
+      backgroundColor: AppColors.cosmicPurple,
+      side: BorderSide(
+        color: isSelected ? AppColors.accent : AppColors.cosmicBorder,
+      ),
+      onSelected: (_) => onSelected(),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_row_item.dart
+++ b/lib/features/score/presentation/widgets/score_row_item.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+import '../../domain/entities/score_entry_model.dart';
+
+class ScoreRowItem extends StatelessWidget {
+  const ScoreRowItem({super.key, required this.score});
+
+  final ScoreEntryModel score;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: AppColors.cosmicBorder, width: 0.5),
+        ),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.2),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              '+${score.points}',
+              style: const TextStyle(
+                color: AppColors.accent,
+                fontWeight: FontWeight.bold,
+                fontFamily: 'Ibrand',
+                fontSize: 16,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  score.formattedDate,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontFamily: 'Ibrand',
+                  ),
+                ),
+                Text(
+                  score.formattedTime,
+                  style: const TextStyle(
+                    color: Colors.white54,
+                    fontSize: 14,
+                    fontFamily: 'Ibrand',
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            '${score.points} pts',
+            style: const TextStyle(
+              color: AppColors.cosmicAccent,
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              fontFamily: 'Ibrand',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_stat_item.dart
+++ b/lib/features/score/presentation/widgets/score_stat_item.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class ScoreStatItem extends StatelessWidget {
+  const ScoreStatItem({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        children: [
+          Icon(
+            icon,
+            color: color,
+            size: 28,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: TextStyle(
+              color: color,
+              fontSize: 36,
+              fontWeight: FontWeight.bold,
+              fontFamily: 'Ibrand',
+              letterSpacing: 1.8,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white70,
+              fontSize: 16,
+              fontFamily: 'Ibrand',
+              letterSpacing: 1.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_summary_card.dart
+++ b/lib/features/score/presentation/widgets/score_summary_card.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+import '../../domain/entities/score_summary_model.dart';
+import 'score_stat_item.dart';
+
+class ScoreSummaryCard extends StatelessWidget {
+  const ScoreSummaryCard({super.key, required this.summary});
+
+  final ScoreSummaryModel? summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [
+            AppColors.cosmicPurple,
+            AppColors.cosmicDarkPurple,
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.cosmicBorder.withValues(alpha: 0.5),
+        ),
+      ),
+      child: Row(
+        children: [
+          ScoreStatItem(
+            icon: Icons.star_rounded,
+            label: 'Total de Pontos',
+            value: '${summary?.totalPoints ?? 0}',
+            color: AppColors.cosmicAccent,
+          ),
+          const SizedBox(width: 32),
+          ScoreStatItem(
+            icon: Icons.calendar_today_rounded,
+            label: 'Dias Ativos',
+            value: '${summary?.pointsByDate.length ?? 0}',
+            color: AppColors.success,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_week_day_cell.dart
+++ b/lib/features/score/presentation/widgets/score_week_day_cell.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/ui/app_colors.dart';
+
+class ScoreWeekDayCell extends StatelessWidget {
+  const ScoreWeekDayCell({
+    super.key,
+    required this.dayNumber,
+    required this.points,
+    required this.isToday,
+    required this.isCurrentMonth,
+  });
+
+  final String dayNumber;
+  final int points;
+  final bool isToday;
+  final bool isCurrentMonth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      decoration: BoxDecoration(
+        color: isToday
+            ? AppColors.accent.withValues(alpha: 0.2)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+        border: isToday
+            ? Border.all(color: AppColors.accent, width: 1.5)
+            : null,
+      ),
+      child: Column(
+        children: [
+          Text(
+            dayNumber,
+            style: TextStyle(
+              color: isCurrentMonth ? Colors.white : Colors.white38,
+              fontSize: 13,
+              fontFamily: 'Ibrand',
+              fontWeight: isToday ? FontWeight.bold : FontWeight.normal,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            points > 0 ? '$points' : '-',
+            style: TextStyle(
+              color: points > 0 ? AppColors.cosmicAccent : Colors.white24,
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              fontFamily: 'Ibrand',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/score/presentation/widgets/score_week_row.dart
+++ b/lib/features/score/presentation/widgets/score_week_row.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/score_week_day_model.dart';
+import 'score_week_day_cell.dart';
+
+class ScoreWeekRow extends StatelessWidget {
+  const ScoreWeekRow({super.key, required this.days});
+
+  final List<ScoreWeekDayModel> days;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: days
+          .map(
+            (day) => Expanded(
+              child: ScoreWeekDayCell(
+                dayNumber: day.dayNumber,
+                points: day.points,
+                isToday: day.isToday,
+                isCurrentMonth: day.isCurrentMonth,
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/features/splash/presentation/pages/splash_page.dart
+++ b/lib/features/splash/presentation/pages/splash_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class SplashPage extends StatelessWidget {
+  const SplashPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,23 +1,16 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:window_manager/window_manager.dart';
 
+import 'core/app/weblurk_app.dart';
 import 'core/application_config.dart';
-import 'core/controllers/update_controller.dart';
 import 'core/di/injector.dart';
 import 'core/helpers/error_handler.dart';
-import 'core/routes/router_config.dart';
 import 'core/services/sentry_service.dart';
-import 'core/services/shorebird_update_service.dart';
-import 'core/ui/ui_config.dart';
-import 'core/ui/widgets/android_back_button_handler.dart';
 
 Future<void> main() async {
-  // Wrapper para inicialização do app
   Future<void> appRunner() async {
-    // Lock orientation to landscape for Android
     if (Platform.isAndroid) {
       await SystemChrome.setPreferredOrientations([
         DeviceOrientation.landscapeLeft,
@@ -27,7 +20,6 @@ Future<void> main() async {
 
     await ApplicationConfig().consfigureApp();
 
-    // Initialize window manager only for Windows and MacOS
     if (Platform.isWindows || Platform.isMacOS) {
       await windowManager.ensureInitialized();
       final WindowOptions windowOptions = const WindowOptions(
@@ -46,62 +38,9 @@ Future<void> main() async {
     runApp(const Weblurk());
   }
 
-  // Sentry desabilitado no Linux devido a incompatibilidade com GLX
-  // Causa: BadAccess error ao tentar acessar recursos gráficos do X Window System
   if (Platform.isLinux) {
     await appRunner();
   } else {
     await SentryService.init(appRunner: appRunner);
-  }
-}
-
-class Weblurk extends StatefulWidget {
-  const Weblurk({super.key});
-
-  @override
-  State<Weblurk> createState() => _WeblurklState();
-}
-
-class _WeblurklState extends State<Weblurk> {
-  @override
-  void initState() {
-    super.initState();
-    _checkForUpdates();
-  }
-
-  Future<void> _checkForUpdates() async {
-    // Aguarda um pequeno delay para garantir que a UI esteja pronta
-    await Future.delayed(const Duration(seconds: 2));
-
-    // Use the new MVVM structure through UpdateController
-    final updateService = ShorebirdUpdateService();
-
-    // Executar diagnóstico primeiro
-    await updateService.debugShorebird();
-
-    final hasUpdate = await updateService.checkForUpdates();
-    if (hasUpdate && mounted) {
-      // Use the new MVVM UpdateController
-      final updateController = UpdateController();
-      await updateController.checkAndShowUpdateDialog(context);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return ScreenUtilInit(
-      designSize: const Size(1366, 768),
-      minTextAdapt: true,
-      splitScreenMode: true,
-      builder: (context, child) {
-        return AndroidBackButtonHandler(
-          child: MaterialApp.router(
-            routerConfig: AppRouter.router,
-            title: UiConfig.title,
-            theme: UiConfig.theme,
-          ),
-        );
-      },
-    );
   }
 }


### PR DESCRIPTION
## Summary
- Add score page where users can view their points with daily, weekly and monthly filters
- Extract Weblurk widget and SplashPage to proper MVVM layers
- Fix login session persistence across app restarts
- Persist GoRouter instance to survive hot reloads

## Changes
- **Score module**: full MVVM implementation with domain entities, repository, service, viewmodel, page and 12 dumb widgets
- **Calendar grid**: week view (1 row) and month view (4 weeks) showing points per day
- **Filters**: today (shows history list), week/month (shows calendar grid only)
- **Menu**: "Pontuação" now navigates to `/score` instead of external Google Sheets
- **Auth**: removed `_hasInitialized` static flag that forced logout on every app start
- **Router**: changed `GoRouter get` to `GoRouter final` to persist across hot reloads